### PR TITLE
Lock pear/archive_tar to 1.4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "consolidation/robo": "~1.0",
         "php": ">=5.5.0",
-        "pear/archive_tar": "^1.4",
+        "pear/archive_tar": "1.4.3",
         "symfony/debug": "^4|^3.4"
     },
     "require-dev": {


### PR DESCRIPTION
See https://pear.php.net/bugs/bug.php?id=23788 & https://github.com/pear/Archive_Tar/pull/21